### PR TITLE
v1.4.8

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-manifest_version=$(node -p "require('./src/assets/manifest.json').version")
+REPO_ROOT=$(git rev-parse --show-toplevel)
+manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,14 +4,22 @@ set -e
 manifest_version=$(node -p "require('./src/assets/manifest.json').version")
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
   remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
-  if echo "$remote_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-    branch_version="${remote_branch#v}"
-    if [ "$branch_version" != "$manifest_version" ]; then
-      echo "Error: pushing to '$remote_branch' but manifest version is '$manifest_version'"
-      echo "Update src/assets/manifest.json to '$branch_version' before pushing."
-      exit 1
-    fi
+
+  if echo "$local_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    version_ref="$local_branch"
+  elif echo "$remote_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    version_ref="$remote_branch"
+  else
+    continue
+  fi
+
+  branch_version="${version_ref#v}"
+  if [ "$branch_version" != "$manifest_version" ]; then
+    echo "Error: branch '$version_ref' but manifest version is '$manifest_version'"
+    echo "Update src/assets/manifest.json to '$branch_version' before pushing."
+    exit 1
   fi
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,21 @@
 #!/bin/sh
 set -e
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if ! echo "$BRANCH" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  exit 0
+fi
+
+BRANCH_VERSION="${BRANCH#v}"
+MANIFEST_VERSION=$(grep -o '"version": "[^"]*"' src/assets/manifest.json | grep -o '[0-9][^"]*')
+
+if [ "$BRANCH_VERSION" != "$MANIFEST_VERSION" ]; then
+  echo "Error: branch '$BRANCH' but manifest version is '$MANIFEST_VERSION'"
+  echo "Update src/assets/manifest.json to '$BRANCH_VERSION' before pushing."
+  exit 1
+fi
+
 pnpm run ci
 pnpm run typecheck
 pnpm run test:coverage

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,21 +6,13 @@ manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').versi
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
-  remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
-
   if echo "$local_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-    version_ref="$local_branch"
-  elif echo "$remote_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-    version_ref="$remote_branch"
-  else
-    continue
-  fi
-
-  branch_version="${version_ref#v}"
-  if [ "$branch_version" != "$manifest_version" ]; then
-    echo "Error: branch is '$version_ref' but manifest version is '$manifest_version'"
-    echo "Update src/assets/manifest.json to '$branch_version' before pushing."
-    exit 1
+    branch_version="${local_branch#v}"
+    if [ "$branch_version" != "$manifest_version" ]; then
+      echo "Error: branch is '$local_branch' but manifest version is '$manifest_version'"
+      echo "Update src/assets/manifest.json to '$branch_version' before pushing."
+      exit 1
+    fi
   fi
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,11 +4,11 @@ set -e
 manifest_version=$(node -p "require('./src/assets/manifest.json').version")
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
-  branch=$(echo "$local_ref" | sed 's|refs/heads/||')
-  if echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-    branch_version="${branch#v}"
+  remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+  if echo "$remote_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    branch_version="${remote_branch#v}"
     if [ "$branch_version" != "$manifest_version" ]; then
-      echo "Error: branch '$branch' but manifest version is '$manifest_version'"
+      echo "Error: pushing to '$remote_branch' but manifest version is '$manifest_version'"
       echo "Update src/assets/manifest.json to '$branch_version' before pushing."
       exit 1
     fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-manifest_version=""
-
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
   remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
@@ -15,10 +13,12 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  if [ -z "$manifest_version" ]; then
-    REPO_ROOT=$(git rev-parse --show-toplevel)
-    manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
+  zero_sha="0000000000000000000000000000000000000000"
+  if [ "$local_sha" = "$zero_sha" ]; then
+    continue
   fi
+
+  manifest_version=$(git show "$local_sha:src/assets/manifest.json" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).version))")
   branch_version="${version_ref#v}"
   if [ "$branch_version" != "$manifest_version" ]; then
     echo "Error: branch is '$version_ref' but manifest version is '$manifest_version'"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,17 +5,25 @@ manifest_version=""
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
+  remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+
   if echo "$local_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-    if [ -z "$manifest_version" ]; then
-      REPO_ROOT=$(git rev-parse --show-toplevel)
-      manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
-    fi
-    branch_version="${local_branch#v}"
-    if [ "$branch_version" != "$manifest_version" ]; then
-      echo "Error: branch is '$local_branch' but manifest version is '$manifest_version'"
-      echo "Update src/assets/manifest.json to '$branch_version' before pushing."
-      exit 1
-    fi
+    version_ref="$local_branch"
+  elif echo "$remote_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    version_ref="$remote_branch"
+  else
+    continue
+  fi
+
+  if [ -z "$manifest_version" ]; then
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
+  fi
+  branch_version="${version_ref#v}"
+  if [ "$branch_version" != "$manifest_version" ]; then
+    echo "Error: branch is '$version_ref' but manifest version is '$manifest_version'"
+    echo "Update src/assets/manifest.json to '$branch_version' before pushing."
+    exit 1
   fi
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,12 @@
 #!/bin/sh
 set -e
 
+manifest_version=$(node -p "require('./src/assets/manifest.json').version")
+
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   branch=$(echo "$local_ref" | sed 's|refs/heads/||')
   if echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
     branch_version="${branch#v}"
-    manifest_version=$(node -p "require('./src/assets/manifest.json').version")
     if [ "$branch_version" != "$manifest_version" ]; then
       echo "Error: branch '$branch' but manifest version is '$manifest_version'"
       echo "Update src/assets/manifest.json to '$branch_version' before pushing."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,7 +17,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
 
   branch_version="${version_ref#v}"
   if [ "$branch_version" != "$manifest_version" ]; then
-    echo "Error: branch '$version_ref' but manifest version is '$manifest_version'"
+    echo "Error: branch is '$version_ref' but manifest version is '$manifest_version'"
     echo "Update src/assets/manifest.json to '$branch_version' before pushing."
     exit 1
   fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,8 +2,8 @@
 set -e
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
-  local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
-  remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+  local_branch="${local_ref#refs/heads/}"
+  remote_branch="${remote_ref#refs/heads/}"
 
   if echo "$local_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
     version_ref="$local_branch"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,7 +18,11 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  manifest_version=$(git show "$local_sha:src/assets/manifest.json" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).version))")
+  if ! git show "$local_sha:src/assets/manifest.json" > /dev/null 2>&1; then
+    echo "Error: src/assets/manifest.json not found in commit $local_sha"
+    exit 1
+  fi
+  manifest_version=$(git show "$local_sha:src/assets/manifest.json" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{process.stdout.write(JSON.parse(d).version)}catch(e){process.stderr.write('Error: invalid JSON or missing version field in src/assets/manifest.json\n');process.exit(1)}})")
   branch_version="${version_ref#v}"
   if [ "$branch_version" != "$manifest_version" ]; then
     echo "Error: branch is '$version_ref' but manifest version is '$manifest_version'"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,12 +1,15 @@
 #!/bin/sh
 set -e
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
+manifest_version=""
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   local_branch=$(echo "$local_ref" | sed 's|refs/heads/||')
   if echo "$local_branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    if [ -z "$manifest_version" ]; then
+      REPO_ROOT=$(git rev-parse --show-toplevel)
+      manifest_version=$(node -p "require('$REPO_ROOT/src/assets/manifest.json').version")
+    fi
     branch_version="${local_branch#v}"
     if [ "$branch_version" != "$manifest_version" ]; then
       echo "Error: branch is '$local_branch' but manifest version is '$manifest_version'"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   branch=$(echo "$local_ref" | sed 's|refs/heads/||')
   if echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
     branch_version="${branch#v}"
-    manifest_version=$(grep -o '"version": "[^"]*"' src/assets/manifest.json | grep -o '[0-9][^"]*')
+    manifest_version=$(node -p "require('./src/assets/manifest.json').version")
     if [ "$branch_version" != "$manifest_version" ]; then
       echo "Error: branch '$branch' but manifest version is '$manifest_version'"
       echo "Update src/assets/manifest.json to '$branch_version' before pushing."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,20 +1,18 @@
 #!/bin/sh
 set -e
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-if ! echo "$BRANCH" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-  exit 0
-fi
-
-BRANCH_VERSION="${BRANCH#v}"
-MANIFEST_VERSION=$(grep -o '"version": "[^"]*"' src/assets/manifest.json | grep -o '[0-9][^"]*')
-
-if [ "$BRANCH_VERSION" != "$MANIFEST_VERSION" ]; then
-  echo "Error: branch '$BRANCH' but manifest version is '$MANIFEST_VERSION'"
-  echo "Update src/assets/manifest.json to '$BRANCH_VERSION' before pushing."
-  exit 1
-fi
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  branch=$(echo "$local_ref" | sed 's|refs/heads/||')
+  if echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    branch_version="${branch#v}"
+    manifest_version=$(grep -o '"version": "[^"]*"' src/assets/manifest.json | grep -o '[0-9][^"]*')
+    if [ "$branch_version" != "$manifest_version" ]; then
+      echo "Error: branch '$branch' but manifest version is '$manifest_version'"
+      echo "Update src/assets/manifest.json to '$branch_version' before pushing."
+      exit 1
+    fi
+  fi
+done
 
 pnpm run ci
 pnpm run typecheck

--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "__MSG_extensionName__",
 	"short_name": "__MSG_extensionShortName__",
-	"version": "1.4.5",
+	"version": "1.4.8",
 	"description": "__MSG_extensionDescription__",
 	"default_locale": "en",
 	"author": "pHo9UBenaA",


### PR DESCRIPTION
This pull request introduces a pre-push Git hook to enforce version consistency between the release branch name and the extension version in `manifest.json`, and updates the extension version.

**Release process improvements:**

* Added a check in `.githooks/pre-push` to ensure that when pushing from a branch named like `vX.Y.Z`, the `version` field in `src/assets/manifest.json` matches the branch version. If they do not match, the push is blocked with an error message.

**Version update:**

* Updated the extension version in `src/assets/manifest.json` from `1.4.5` to `1.4.8`.